### PR TITLE
Fix SSL: CERTIFICATE_VERIFY_FAILED when setting up RingRTC

### DIFF
--- a/SignalRingRTC/bin/fetch-artifact.py
+++ b/SignalRingRTC/bin/fetch-artifact.py
@@ -9,6 +9,7 @@ import argparse
 import hashlib
 import os
 import platform
+import ssl
 import sys
 import tarfile
 import urllib.request
@@ -99,7 +100,8 @@ def download_if_needed(archive_file: str, url: str, checksum: str, archive_dir: 
 
     print("downloading {}...".format(archive_file), file=sys.stderr)
     try:
-        with urllib.request.urlopen(url) as response:
+        ssl_context = ssl.create_default_context()
+        with urllib.request.urlopen(url, context=ssl_context) as response:
             digest = hashlib.sha256()
             download_path = os.path.join(archive_dir, UNVERIFIED_DOWNLOAD_NAME)
             f = open(download_path, 'w+b')


### PR DESCRIPTION
With system python3 on macOS 14.3.1 (Python 3.11.4), certificate verification fails for build-artifacts.signal.org. This is causing `make dependencies` to fail.

To correctly load the system certificate chain, `urllib.request.urlopen()` must be passed a properly-configured `ssl.SSLContext`. Using `ssl.create_default_context()` appears to do the correct thing by default, and should be valid in Python >= 3.4.