### PR TITLE
YYImage: Tolerate ancillary chunks between APNG chunks

### DIFF
--- a/YYImage/YYImage/YYImageCoder.m
+++ b/YYImage/YYImage/YYImageCoder.m
@@ -439,8 +439,13 @@ static yy_png_info *yy_png_info_create(const uint8_t *data, uint32_t length) {
         chunk->fourcc = *((uint32_t *)(chunk_data + 4));
         if ((uint64_t)chunk->offset + 4 + chunk->length + 4 > (uint64_t)length) break;
         chunk->crc32 = yy_swap_endian_uint32(*((uint32_t *)(chunk_data + 8 + chunk->length)));
-        chunk_num++;
         offset += 12 + chunk->length;
+        if (chunk->fourcc == YY_FOUR_CC('t', 'E', 'X', 't') ||
+            chunk->fourcc == YY_FOUR_CC('z', 'T', 'X', 't') ||
+            chunk->fourcc == YY_FOUR_CC('i', 'T', 'X', 't')) {
+            continue;
+        }
+        chunk_num++;
         
         switch (chunk->fourcc) {
             case YY_FOUR_CC('a', 'c', 'T', 'L') : {


### PR DESCRIPTION
Fixes: https://github.com/signalapp/Signal-iOS/issues/4611
Fixes: https://github.com/signalapp/Signal-iOS/issues/5320

YYImage has the wrong assumption that a fcTL chunk must come right before the frame data chunk it belongs to.
[PNG specification](https://www.w3.org/TR/png-3) only requires three things:
- If the first fcTL belongs to IDAT, it must be before IDAT.
- fdAT chunks must come after the fcTL it belongs to, and it must be before the next fcTL
- The fcTL-fdAT chunks must be in order, if the sequence numbers are out of sequence its an error.
But, other chunks can be in between the APNG chunks.

This PR simplifies and fixes the APNG parsing inside YYImage. Also:
- Skip text chunks and such during parsing. As YYImage encodes a new PNG for every frame (`yy_png_copy_frame_data_at_index`), it has to copy every chunk in the original PNG to all frames. (because there might be crucial chunks like PLTE, tRNS etc.)
- Do not copy any chunk after IDAT (except IEND) while encoding a frame. (There is no standardized chunk type that can appear after IDAT which would affect image decoding.)